### PR TITLE
Solucion error. vibracion de camara

### DIFF
--- a/Assets/Niveles/NivelPrueba/Test.unity
+++ b/Assets/Niveles/NivelPrueba/Test.unity
@@ -416,7 +416,7 @@ Transform:
   m_GameObject: {fileID: 1170527794}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 12.005232, y: -9.158266, z: -16.241894}
-  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_LocalScale: {x: 100, y: 10, z: 100}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2

--- a/Assets/libsm64-unity/Samples/SampleScene/ExampleScene.unity
+++ b/Assets/libsm64-unity/Samples/SampleScene/ExampleScene.unity
@@ -453,9 +453,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 963194228}
-  - component: {fileID: 963194229}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -537,7 +537,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e950f4e30d23590c5930ee596c555fe9, type: 3}
+  m_Script: {fileID: 11500000, guid: fdb85c1fb8105c545bfd23287a6c3495, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 1677693779}
@@ -1059,10 +1059,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 1677693779}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4a2dace33993b19abc35c88b9b40604, type: 3}
+  m_Script: {fileID: 11500000, guid: 01472004e2c74af46a45ebe0c7799fa8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   cameraObject: {fileID: 963194225}
+  mouseSensitivity: 2
+  cameraDistance: 5
+  zoomSpeed: 2
+  minZoom: 2
+  maxZoom: 10
 --- !u!1 &1683195583
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/libsm64-unity/Samples/nivel 1/Camara.cs
+++ b/Assets/libsm64-unity/Samples/nivel 1/Camara.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine;
 using LibSM64;
 
@@ -10,16 +10,15 @@ public class Camara : MonoBehaviour
 
     void LateUpdate()
     {
-        var m = target.transform.position;
-        var n = transform.position;
-        m.y = 0;
-        n.y = 0;
-        n = (n - m).normalized * radius;
-        n = Quaternion.AngleAxis( Input.GetAxis("HorizontalCam"), Vector3.up ) * n;
-        n += m;
-        n.y = target.transform.position.y + elevation;
 
-        transform.position = n;
-        transform.LookAt( target.transform.position );
+        Vector3 m = target.transform.position;
+
+        Vector3 dir = transform.forward;
+
+        Vector3 desiredPos = m - dir * radius;
+        desiredPos.y = m.y + elevation;
+
+        transform.position = desiredPos;
+
     }
 }

--- a/Assets/libsm64-unity/Samples/nivel 1/input.cs
+++ b/Assets/libsm64-unity/Samples/nivel 1/input.cs
@@ -4,9 +4,11 @@ using LibSM64;
 public class input : SM64InputProvider
 {
     public GameObject cameraObject;
+
+
     public float mouseSensitivity = 2.0f;
     private float yaw = 0f;
-    private float pitch = 0f;
+    private float pitch = 35f;
 
     public float cameraDistance = 5f;
     public float zoomSpeed = 2f;
@@ -23,15 +25,18 @@ public class input : SM64InputProvider
     {
         // Rotación de cámara con el mouse
         float mouseX = Input.GetAxis("Mouse X") * mouseSensitivity;
-        float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity;
+        //float mouseY = Input.GetAxis("Mouse Y") * mouseSensitivity;
         yaw += mouseX;
-        pitch -= mouseY;
-        pitch = Mathf.Clamp(pitch, -80f, 80f);
+       // pitch -= mouseY;
+       // pitch = Mathf.Clamp(pitch, -80f, 80f);
 
         // Zoom con scroll
         float scroll = Input.GetAxis("Mouse ScrollWheel");
         cameraDistance -= scroll * zoomSpeed;
         cameraDistance = Mathf.Clamp(cameraDistance, minZoom, maxZoom);
+
+
+
 
         cameraObject.transform.rotation = Quaternion.Euler(pitch, yaw, 0f);
 
@@ -40,8 +45,8 @@ public class input : SM64InputProvider
         Vector3 desiredCamPos = marioPos - cameraObject.transform.forward * cameraDistance;
         cameraObject.transform.position = desiredCamPos;
         cameraObject.transform.LookAt(marioPos + Vector3.up * 1.5f);
-    }
 
+    }
     public override Vector3 GetCameraLookDirection()
     {
         return cameraObject.transform.forward;
@@ -62,8 +67,8 @@ public class input : SM64InputProvider
                 return Input.GetMouseButton(0); // clic izquierdo
             case Button.Stomp:
                 return Input.GetKey(KeyCode.LeftShift);
-            
+
         }
-        return false;
-    }
+        return false;
+    }
 }

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -61,8 +61,8 @@ InputManager:
     positiveButton: right
     altNegativeButton: a
     altPositiveButton: d
-    gravity: 3
-    dead: 0.001
+    gravity: 2
+    dead: 0.19
     sensitivity: 3
     snap: 0
     invert: 0
@@ -93,8 +93,8 @@ InputManager:
     positiveButton: up
     altNegativeButton: s
     altPositiveButton: w
-    gravity: 3
-    dead: 0.001
+    gravity: 2
+    dead: 0.19
     sensitivity: 3
     snap: 0
     invert: 0
@@ -132,22 +132,6 @@ InputManager:
     invert: 0
     type: 1
     axis: 0
-    joyNum: 0
-  - serializedVersion: 3
-    m_Name: Mouse Y
-    descriptiveName: 
-    descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: 
-    altNegativeButton: 
-    altPositiveButton: 
-    gravity: 0
-    dead: 0.001
-    sensitivity: 1
-    snap: 0
-    invert: 0
-    type: 1
-    axis: 1
     joyNum: 0
   - serializedVersion: 3
     m_Name: Mouse ScrollWheel


### PR DESCRIPTION
se solucionó un error de la cámara en la cual se sobreponían dos diferentes movimientos, generando una vibración